### PR TITLE
feat(storage): 为数据库和缓存添加 Ping 方法用于健康检查

### DIFF
--- a/middleware/storage/cache/bbolt.go
+++ b/middleware/storage/cache/bbolt.go
@@ -797,6 +797,17 @@ func (p *CacheBbolt) Reset() error {
 	})
 }
 
+func (p *CacheBbolt) Ping() error {
+	err := p.conn.View(func(tx *bbolt.Tx) error {
+		return nil
+	})
+	if err != nil {
+		log.Errorf("err:%v", err)
+		return err
+	}
+	return nil
+}
+
 func NewBbolt(addr string, options *bbolt.Options) (Cache, error) {
 	prefix := app.Name
 	if prefix == "" {

--- a/middleware/storage/cache/bitcask.go
+++ b/middleware/storage/cache/bitcask.go
@@ -585,6 +585,15 @@ func (p *CacheBitcask) SetPrefix(prefix string) {
 	p.prefix = prefix
 }
 
+func (p *CacheBitcask) Ping() error {
+	err := p.cli.Sync()
+	if err != nil {
+		log.Errorf("err:%v", err)
+		return err
+	}
+	return nil
+}
+
 func NewBitcask(c *Config) (Cache, error) {
 	var err error
 	p := &CacheBitcask{}

--- a/middleware/storage/cache/cache.go
+++ b/middleware/storage/cache/cache.go
@@ -57,6 +57,8 @@ type BaseCache interface {
 
 	Clean() error
 	Close() error
+
+	Ping() error
 }
 
 type Cache interface {

--- a/middleware/storage/cache/database.go
+++ b/middleware/storage/cache/database.go
@@ -241,6 +241,15 @@ func (p *Database) SetPrefix(prefix string) {
 	p.prefix = prefix
 }
 
+func (p *Database) Ping() error {
+	err := p.db.Ping()
+	if err != nil {
+		log.Errorf("err:%v", err)
+		return err
+	}
+	return nil
+}
+
 func NewDatabase(db *sql.DB, tableName string) (Cache, error) {
 	p := &Database{
 		db:        db,

--- a/middleware/storage/cache/echo.go
+++ b/middleware/storage/cache/echo.go
@@ -339,6 +339,16 @@ func (p *CacheSugarDB) Close() error {
 	return nil
 }
 
+func (p *CacheSugarDB) Ping() error {
+	// SugarDB doesn't have Ping method, use DBSize as health check
+	_, err := p.cli.DBSize()
+	if err != nil {
+		log.Errorf("err:%v", err)
+		return err
+	}
+	return nil
+}
+
 func NewSugarDB(c *Config) (Cache, error) {
 	ec := sugardb.DefaultConfig()
 	if c.DataDir != "" {

--- a/middleware/storage/cache/leveldb.go
+++ b/middleware/storage/cache/leveldb.go
@@ -590,6 +590,15 @@ func (p *CacheLevelDB) SetPrefix(prefix string) {
 	p.prefix = prefix
 }
 
+func (p *CacheLevelDB) Ping() error {
+	_, err := p.db.GetProperty("leveldb.stats")
+	if err != nil {
+		log.Errorf("err:%v", err)
+		return err
+	}
+	return nil
+}
+
 func NewLevelDB(c *Config) (Cache, error) {
 	var err error
 	p := &CacheLevelDB{}

--- a/middleware/storage/cache/mem.go
+++ b/middleware/storage/cache/mem.go
@@ -674,6 +674,10 @@ func (p *CacheMem) Reset() error {
 	return nil
 }
 
+func (p *CacheMem) Ping() error {
+	return nil
+}
+
 func NewMem() Cache {
 	p := &CacheMem{
 		data: make(map[string]*Item),

--- a/middleware/storage/cache/redis.go
+++ b/middleware/storage/cache/redis.go
@@ -469,3 +469,12 @@ func (p *CacheRedis) Close() error {
 	}
 	return nil
 }
+
+func (p *CacheRedis) Ping() error {
+	_, err := p.cli.Ping()
+	if err != nil {
+		log.Errorf("err:%v", err)
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- 为数据库 Client 添加 `Ping()` 方法用于检测数据库连接状态
- 为所有缓存实现添加 `Ping()` 方法用于健康检查和可用性检测
- 统一错误处理规范，所有实现都记录错误日志并返回错误

## Changes

### Database (db/client.go)
- 添加 `Ping()` 方法，通过底层 `sql.DB.Ping()` 检测连接状态
- 遵循项目的错误处理规范（分离赋值和检查，记录错误日志）

### Cache Implementations
为所有缓存实现添加 `Ping()` 方法：

1. **Redis**: 使用原生 `cli.Ping()` 方法
2. **Memory**: 内存缓存无需检测，直接返回成功
3. **Bbolt**: 通过只读事务 `conn.View()` 检测数据库连接
4. **Bitcask**: 使用 `cli.Sync()` 方法检测
5. **LevelDB**: 使用 `db.GetProperty("leveldb.stats")` 检测
6. **Database**: 使用底层 `sql.DB.Ping()` 方法
7. **SugarDB**: 使用 `cli.DBSize()` 方法检测（因为没有原生 Ping 方法）

## Benefits
- 方便应用层进行健康检查和连接状态监控
- 统一的接口设计，所有存储层都支持 Ping 检测
- 完整的错误处理和日志记录

## Test plan
- [x] 编译通过
- [ ] 单元测试验证 Ping 方法的正常场景
- [ ] 验证连接断开时的错误处理
- [ ] 确认错误日志正确记录

🤖 Generated with [Claude Code](https://claude.com/claude-code)