### PR TITLE
refactor(db): 移除初始化时的强制 Ping 检查

### DIFF
--- a/middleware/storage/db/client.go
+++ b/middleware/storage/db/client.go
@@ -164,19 +164,6 @@ func New(c *Config, tables ...interface{}) (*Client, error) {
 		p.db = p.db.Debug()
 	}
 
-	// 验证数据库连接
-	sqlDB, err := p.db.DB()
-	if err != nil {
-		log.Errorf("failed to get sql.DB: %v", err)
-		return nil, err
-	}
-
-	err = sqlDB.Ping()
-	if err != nil {
-		log.Errorf("failed to ping database: %v", err)
-		return nil, err
-	}
-
 	err = p.AutoMigrates(tables...)
 	if err != nil {
 		log.Errorf("err:%v", err)


### PR DESCRIPTION
## Summary
- 移除 `New()` 函数中的数据库连接验证
- 用户可以根据需要在适当的时机调用 `Ping()` 方法进行健康检查
- 提高数据库初始化的灵活性

## Changes
移除了 `New()` 函数中的强制 Ping 检查代码：
```go
// 移除了这部分代码
sqlDB, err := p.db.DB()
if err != nil {
    log.Errorf("failed to get sql.DB: %v", err)
    return nil, err
}

err = sqlDB.Ping()
if err != nil {
    log.Errorf("failed to ping database: %v", err)
    return nil, err
}
```

## Benefits
- **更灵活的初始化**：不强制在初始化时进行连接检查
- **按需检查**：用户可以在需要时调用 `Ping()` 方法
- **适应更多场景**：
  - 延迟连接场景
  - 连接池预热
  - 数据库暂时不可用但仍需初始化应用的场景

## Backward Compatibility
这是一个向后兼容的改动。之前依赖初始化时连接检查的代码，可以在 `New()` 之后立即调用 `Ping()` 来保持相同的行为。

## Test plan
- [x] 编译通过
- [ ] 验证不影响正常的数据库操作
- [ ] 验证 Ping() 方法仍然可以正常工作

🤖 Generated with [Claude Code](https://claude.com/claude-code)