### PR TITLE
feat(storage): 使用 atexit 在系统退出时自动关闭数据库和缓存连接

### DIFF
--- a/middleware/storage/cache/bbolt.go
+++ b/middleware/storage/cache/bbolt.go
@@ -8,6 +8,7 @@ import (
 	"github.com/beefsack/go-rate"
 	"github.com/lazygophers/log"
 	"github.com/lazygophers/utils/app"
+	"github.com/lazygophers/utils/atexit"
 	"github.com/lazygophers/utils/candy"
 	"github.com/lazygophers/utils/json"
 	"go.etcd.io/bbolt"
@@ -830,6 +831,14 @@ func NewBbolt(addr string, options *bbolt.Options) (Cache, error) {
 	})
 
 	p.conn = conn
+
+	atexit.Register(func() {
+		err := p.Close()
+		if err != nil {
+			log.Errorf("err:%v", err)
+			return
+		}
+	})
 
 	return newBaseCache(p), nil
 }

--- a/middleware/storage/cache/echo.go
+++ b/middleware/storage/cache/echo.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/echovault/sugardb/sugardb"
 	"github.com/lazygophers/log"
+	"github.com/lazygophers/utils/atexit"
 	"github.com/lazygophers/utils/candy"
 )
 
@@ -374,6 +375,14 @@ func NewSugarDB(c *Config) (Cache, error) {
 	p := &CacheSugarDB{
 		cli: cli,
 	}
+
+	atexit.Register(func() {
+		err := p.Close()
+		if err != nil {
+			log.Errorf("err:%v", err)
+			return
+		}
+	})
 
 	return newBaseCache(p), nil
 }

--- a/middleware/storage/cache/mem.go
+++ b/middleware/storage/cache/mem.go
@@ -4,12 +4,13 @@ import (
 	"encoding/json"
 	"math/rand"
 	"strconv"
-
-	"github.com/beefsack/go-rate"
-	"gorm.io/gorm/utils"
-
 	"sync"
 	"time"
+
+	"github.com/beefsack/go-rate"
+	"github.com/lazygophers/log"
+	"github.com/lazygophers/utils/atexit"
+	"gorm.io/gorm/utils"
 )
 
 type CacheMem struct {
@@ -683,6 +684,14 @@ func NewMem() Cache {
 		data: make(map[string]*Item),
 		rt:   rate.New(2, time.Minute),
 	}
+
+	atexit.Register(func() {
+		err := p.Close()
+		if err != nil {
+			log.Errorf("err:%v", err)
+			return
+		}
+	})
 
 	return newBaseCache(p)
 }

--- a/middleware/storage/db/client.go
+++ b/middleware/storage/db/client.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/lazygophers/log"
+	"github.com/lazygophers/utils/atexit"
 	"github.com/lazygophers/utils/candy"
 
 	mysqlC "github.com/go-sql-driver/mysql"
@@ -182,6 +183,15 @@ func New(c *Config, tables ...interface{}) (*Client, error) {
 			// 不返回错误，因为这是优化设置，失败不应阻止初始化
 		}
 	}
+
+	// 注册退出时自动关闭数据库连接
+	atexit.Register(func() {
+		err := p.Close()
+		if err != nil {
+			log.Errorf("err:%v", err)
+			return
+		}
+	})
 
 	return p, nil
 }
@@ -408,6 +418,22 @@ func (p *Client) Ping() error {
 	}
 
 	err = sqlDB.Ping()
+	if err != nil {
+		log.Errorf("err:%v", err)
+		return err
+	}
+
+	return nil
+}
+
+func (p *Client) Close() error {
+	sqlDB, err := p.db.DB()
+	if err != nil {
+		log.Errorf("err:%v", err)
+		return err
+	}
+
+	err = sqlDB.Close()
 	if err != nil {
 		log.Errorf("err:%v", err)
 		return err


### PR DESCRIPTION
## Summary
为数据库和所有缓存实现添加自动资源清理机制，使用 `atexit` 在系统退出时自动关闭连接，避免资源泄漏。

## Changes

### Database (db/client.go)
- 添加 `Close()` 方法用于关闭数据库连接
- 在 `New()` 函数中注册 `atexit.Register()` 自动清理
- 遵循项目的错误处理规范

### Cache Implementations
为以下缓存实现添加 `atexit` 注册：

#### 新增 atexit 支持
1. **Bbolt**: 注册 atexit 自动关闭连接
2. **Memory**: 注册 atexit 自动清理内存缓存
3. **SugarDB**: 注册 atexit 自动关闭

#### 已有 atexit 支持（无需修改）
1. **Redis**: 已有 atexit 注册
2. **Bitcask**: 已有 atexit 注册
3. **LevelDB**: 已有 atexit 注册

#### 不需要 atexit
- **Database**: 使用外部传入的 sql.DB，生命周期由调用者管理

## Benefits
- **自动资源清理**：无需手动调用 Close()，系统退出时自动清理
- **避免资源泄漏**：确保所有连接在程序退出时正确关闭
- **数据持久化保证**：确保缓存数据在退出前正确写入磁盘
- **统一的资源管理**：所有存储层使用相同的资源管理模式
- **优雅退出**：遵循 Go 的最佳实践，确保程序优雅关闭

## Implementation Details

### Database Close 方法
```go
func (p *Client) Close() error {
    sqlDB, err := p.db.DB()
    if err != nil {
        log.Errorf("err:%v", err)
        return err
    }
    
    err = sqlDB.Close()
    if err != nil {
        log.Errorf("err:%v", err)
        return err
    }
    
    return nil
}
```

### Atexit 注册模式
```go
atexit.Register(func() {
    err := p.Close()
    if err != nil {
        log.Errorf("err:%v", err)
        return
    }
})
```

## Backward Compatibility
完全向后兼容。现有代码可以继续手动调用 `Close()` 方法，atexit 只是提供额外的安全保障。

## Test plan
- [x] 编译通过
- [ ] 验证 atexit 正常触发
- [ ] 验证连接正确关闭
- [ ] 验证数据正确持久化

🤖 Generated with [Claude Code](https://claude.com/claude-code)